### PR TITLE
Support customize data path port

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ docker_swarm_addr: "{{ hostvars[inventory_hostname]['ansible_' + docker_swarm_in
 # Define Docker swarm listen port
 docker_swarm_port: "2377"
 
+# Define Docker swarm data path port
+docker_swarm_data_path_port: ''
+
 
 # Define Ansible group which contains your Docker swarm managers
 docker_swarm_managers_ansible_group: 'docker-swarm-managers'

--- a/README.md
+++ b/README.md
@@ -16,24 +16,33 @@ Role Variables
 
 ```
 ---
+---
 # defaults file for ansible-docker-swarm
+
+# Define Docker interface to auto fill `docker_swarm_addr`
+docker_swarm_interface: "enp0s8"
+
+# Define Docker swarm listen and advertise address
 docker_swarm_addr: "{{ hostvars[inventory_hostname]['ansible_' + docker_swarm_interface]['ipv4']['address'] }}"
 
-# Validity period for node certificates (default 2160h0m0s)
-docker_swarm_cert_expiry: '2160h0m0s'
+# Define Docker swarm listen port
+docker_swarm_port: "2377"
 
-# Dispatcher heartbeat period (default 5s)
-docker_swarm_dispatcher_heartbeat_duration: '5s'
-
-docker_swarm_interface: "enp0s8"
-# docker_swarm_managers_ansible_group: 'docker-swarm-managers'
-
-docker_swarm_config_networks: false
-docker_swarm_config_settings: false
 
 # Define Ansible group which contains your Docker swarm managers
 docker_swarm_managers_ansible_group: 'docker-swarm-managers'
 
+# Define Ansible group which contains you Docker swarm workers
+docker_swarm_workers_ansible_group: 'docker-swarm-workers'
+
+# Defines first node in docker_swarm_managers_ansible_group as primary
+docker_swarm_primary_manager: '{{ groups[docker_swarm_managers_ansible_group][0] }}'
+
+
+# Define Docker swarm network customizations
+docker_swarm_config_networks: false
+
+# Network: see community.docker.docker_network
 docker_swarm_networks: []
   # - name: 'my_net'
   #   driver: 'overlay'
@@ -41,16 +50,19 @@ docker_swarm_networks: []
   # - name: 'test'
   #   driver: 'overlay'
   #   state: 'absent'
-docker_swarm_port: "2377"
 
-# Defines first node in docker_swarm_managers_ansible_group as primary
-docker_swarm_primary_manager: '{{ groups[docker_swarm_managers_ansible_group][0] }}'
 
-# Task history retention limit (default 5)
+# Define Docker swarm setting customizations
+docker_swarm_config_settings: false
+
+# Setting: Validity period for node certificates (default 2160h0m0s)
+docker_swarm_cert_expiry: '2160h0m0s'
+
+# Setting: Dispatcher heartbeat period (default 5s)
+docker_swarm_dispatcher_heartbeat_duration: '5s'
+
+# Setting: Task history retention limit (default 5)
 docker_swarm_task_history_limit: '5'
-
-# Define Ansible group which contains you Docker swarm workers
-docker_swarm_workers_ansible_group: 'docker-swarm-workers'
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,22 +1,30 @@
 ---
 # defaults file for ansible-docker-swarm
+
+# Define Docker interface to auto fill `docker_swarm_addr`
+docker_swarm_interface: "enp0s8"
+
+# Define Docker swarm listen and advertise address
 docker_swarm_addr: "{{ hostvars[inventory_hostname]['ansible_' + docker_swarm_interface]['ipv4']['address'] }}"
 
-# Validity period for node certificates (default 2160h0m0s)
-docker_swarm_cert_expiry: '2160h0m0s'
+# Define Docker swarm listen port
+docker_swarm_port: "2377"
 
-# Dispatcher heartbeat period (default 5s)
-docker_swarm_dispatcher_heartbeat_duration: '5s'
-
-docker_swarm_interface: "enp0s8"
-# docker_swarm_managers_ansible_group: 'docker-swarm-managers'
-
-docker_swarm_config_networks: false
-docker_swarm_config_settings: false
 
 # Define Ansible group which contains your Docker swarm managers
 docker_swarm_managers_ansible_group: 'docker-swarm-managers'
 
+# Define Ansible group which contains you Docker swarm workers
+docker_swarm_workers_ansible_group: 'docker-swarm-workers'
+
+# Defines first node in docker_swarm_managers_ansible_group as primary
+docker_swarm_primary_manager: '{{ groups[docker_swarm_managers_ansible_group][0] }}'
+
+
+# Define Docker swarm network customizations
+docker_swarm_config_networks: false
+
+# Network: see community.docker.docker_network
 docker_swarm_networks: []
   # - name: 'my_net'
   #   driver: 'overlay'
@@ -24,13 +32,16 @@ docker_swarm_networks: []
   # - name: 'test'
   #   driver: 'overlay'
   #   state: 'absent'
-docker_swarm_port: "2377"
 
-# Defines first node in docker_swarm_managers_ansible_group as primary
-docker_swarm_primary_manager: '{{ groups[docker_swarm_managers_ansible_group][0] }}'
 
-# Task history retention limit (default 5)
+# Define Docker swarm setting customizations
+docker_swarm_config_settings: false
+
+# Setting: Validity period for node certificates (default 2160h0m0s)
+docker_swarm_cert_expiry: '2160h0m0s'
+
+# Setting: Dispatcher heartbeat period (default 5s)
+docker_swarm_dispatcher_heartbeat_duration: '5s'
+
+# Setting: Task history retention limit (default 5)
 docker_swarm_task_history_limit: '5'
-
-# Define Ansible group which contains you Docker swarm workers
-docker_swarm_workers_ansible_group: 'docker-swarm-workers'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ docker_swarm_addr: "{{ hostvars[inventory_hostname]['ansible_' + docker_swarm_in
 # Define Docker swarm listen port
 docker_swarm_port: "2377"
 
+# Define Docker swarm data path port
+docker_swarm_data_path_port: ''
+
 
 # Define Ansible group which contains your Docker swarm managers
 docker_swarm_managers_ansible_group: 'docker-swarm-managers'

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -11,6 +11,7 @@
           docker swarm init
           --listen-addr {{ docker_swarm_addr }}:{{ docker_swarm_port }}
           --advertise-addr {{ docker_swarm_addr }}
+          {{ (docker_swarm_data_path_port == '') | ternary('', '--data-path-port=' + docker_swarm_data_path_port) }}
   become: true
   when: >
         'Swarm: inactive' in docker_info.stdout and


### PR DESCRIPTION
Add [data-path-port](https://docs.docker.com/engine/reference/commandline/swarm_init/#--data-path-port) when swarm init.

Sometimes it is necessary to adjust the default 4789 port, for example on esxi: 
https://forums.docker.com/t/docker-swarm-mesh-networking-not-working-as-expected-on-ubuntu-22-04-server/138080/7